### PR TITLE
查看持仓新增@查看看人

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -218,7 +218,7 @@ async def _(event: MessageEvent, bot: Bot, args: Message = CommandArg(), arg: Me
             await sell_stock.finish(MessageSegment.image(await text_to_pic("仓位是空的", width=300)))
         txt = convert_stocks_to_md_table(my_stocks)
         logger.info(txt)
-        await sell_stock.finish(MessageSegment.image(await md_to_pic(f"{txt}", width=1200)))
+        await sell_stock.finish(MessageSegment.image(await md_to_pic(f"{txt}", width=1200)), at_sender=True)
 
 
 # 这是一个测试用管理员指令，不能滥用


### PR DESCRIPTION
当多人查看持仓的时候，只有发送多个图片显得有些混乱。
所以添加了发送图片同时@请求人